### PR TITLE
Update definition of error_with_code()

### DIFF
--- a/errors.h
+++ b/errors.h
@@ -6,7 +6,7 @@ void show_color();
 
 void hide_color();
 
-void error_with_code();
+void error_with_code(char *message, int code);
 
 void print_error(char *message);
 


### PR DESCRIPTION
Some compilers (clang for example) require type declaration in headers to match with their implementations, so this fixes it. Addresses #1 